### PR TITLE
Update for cpu mode support

### DIFF
--- a/scripts/evaluate_flic.py
+++ b/scripts/evaluate_flic.py
@@ -99,6 +99,9 @@ def test(args):
         if args.gpu >= 0:
             input_data = cuda.to_gpu(input_data.astype(np.float32))
             labels = cuda.to_gpu(labels.astype(np.float32))
+        else:
+            input_data = input_data.astype(np.float32)
+            labels = labels.astype(np.float32)
 
         x = Variable(input_data, volatile=True)
         t = Variable(labels, volatile=True)
@@ -108,6 +111,8 @@ def test(args):
             preds = cuda.to_cpu(model.pred.data)
             input_data = cuda.to_cpu(input_data)
             labels = cuda.to_cpu(labels)
+        else:
+            preds = model.pred.data
 
         for n, line in enumerate(lines):
             img_fn = line.split(',')[args.fname_index]


### PR DESCRIPTION
When I tried to run `scripts/evaluate_flic.py` with `--mode test` `--gpu -1`, the following error occurred, so I added cpu mode code.
```
Traceback (most recent call last):
  File "scripts/evaluate_flic.py", line 214, in <module>
    test(args)
  File "scripts/evaluate_flic.py", line 105, in test
    model(x, t)
  File "results/AlexNet_flic_2016-03-16_03-42-31/AlexNet_flic.py", line 29, in __call__
    h = F.relu(self.conv1(x))
  File "/usr/local/lib/python2.7/dist-packages/chainer-1.7.1-py2.7-linux-x86_64.egg/chainer/links/connection/convolution_2d.py", line 77, in __call__
    x, self.W, self.b, self.stride, self.pad, self.use_cudnn)
  File "/usr/local/lib/python2.7/dist-packages/chainer-1.7.1-py2.7-linux-x86_64.egg/chainer/functions/connection/convolution_2d.py", line 317, in convolution_2d
    return func(x, W, b)
  File "/usr/local/lib/python2.7/dist-packages/chainer-1.7.1-py2.7-linux-x86_64.egg/chainer/function.py", line 110, in __call__
    self._check_data_type_forward(in_data)
  File "/usr/local/lib/python2.7/dist-packages/chainer-1.7.1-py2.7-linux-x86_64.egg/chainer/function.py", line 185, in _check_data_type_forward
    raise type_check.InvalidType(e.expect, e.actual, msg=msg)
chainer.utils.type_check.InvalidType: 
Invalid operation is performed in: Convolution2DFunction (Forward)

Expect: in_types[0].dtype == <type 'numpy.float32'>
Actual: float64 != <type 'numpy.float32'>
```