### PR TITLE
Changed __call__ func when model.train is False

### DIFF
--- a/models/ResNet50.py
+++ b/models/ResNet50.py
@@ -116,4 +116,5 @@ class ResNet50(chainer.Chain):
             self.loss = mean_squared_error(self.pred, t)
             return self.loss
         else:
+            self.loss = mean_squared_error(self.pred, t)
             return self.pred


### PR DESCRIPTION
Hi, @mitmul thank you for the codes.

I faced an error when I am running train of ResNet50 on my environment:
python scripts/train.py \
--model models/ResNet50.py \
--gpu 0 \
--datadir data/FLIC-full \
(....... and other settings)

Error subscription is not saved unfortunately, but occurred in https://github.com/mitmul/deeppose/blob/master/scripts/train.py#L203 . The message said sth like "Nonetype doesn't have .data". This suggests model.data is None temporally.

I think the function "one_epoch" in scripts/train.py DOES need to calculate model.loss in the TEST session. So I changed and now working.
Although I didn't face this error when running AlexNet because only it doesn't have function "clear()" like ResNet50, this bug may be also in the other model file? Thanks.
